### PR TITLE
docs(base-frameworks): add Dressage to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <div align="center">
 
-![Base Framework](https://img.shields.io/badge/Base_Framework-23-BFA2DB?style=for-the-badge)
+![Base Framework](https://img.shields.io/badge/Base_Framework-24-BFA2DB?style=for-the-badge)
 ![General](https://img.shields.io/badge/General-21-4E6813?style=for-the-badge)
 ![Search & RAG](https://img.shields.io/badge/Search_&_RAG-45-845C40?style=for-the-badge)
 ![Web & GUI](https://img.shields.io/badge/Web_&_GUI-32-A259FF?style=for-the-badge)
@@ -82,7 +82,7 @@ Some Enumeration:
   <img src="AgentsMeetRL_Skill_landscape.png" alt="Logo" width="600">
 </div>
 
-This list is also packaged as a **[Claude Code](https://claude.com/claude-code) Skill** — [`agents-meet-rl`](skills/agents-meet-rl) — that turns the corpus into an on-demand assistant for **agentic-RL training, evaluation, and experiment design**: reward not moving, KL / entropy / length blow-ups, GRPO / PPO / DAPO knobs, retokenization drift, tool-call parse failures, long-horizon credit assignment, LLM-judge inconsistency, benchmark contamination, and framework / benchmark / algorithm selection — each answer anchored to specific papers and repos from this list. Backed by a machine-readable corpus of **368 projects** (snapshot **2026-07-23**). Once installed, Claude Code auto-invokes it whenever your question matches.
+This list is also packaged as a **[Claude Code](https://claude.com/claude-code) Skill** — [`agents-meet-rl`](skills/agents-meet-rl) — that turns the corpus into an on-demand assistant for **agentic-RL training, evaluation, and experiment design**: reward not moving, KL / entropy / length blow-ups, GRPO / PPO / DAPO knobs, retokenization drift, tool-call parse failures, long-horizon credit assignment, LLM-judge inconsistency, benchmark contamination, and framework / benchmark / algorithm selection — each answer anchored to specific papers and repos from this list. Backed by a machine-readable corpus of **369 projects** (snapshot **2026-07-23**). Once installed, Claude Code auto-invokes it whenever your question matches.
 
 **Install as a plugin (recommended):**
 
@@ -107,6 +107,7 @@ Then just ask, e.g. *"my GRPO search agent's reward is flat but eval keeps dropp
 | :----: | :----: | :----: |  :----: | :----: |
 | [AgentJet](https://github.com/modelscope/AgentJet) | <img src="https://img.shields.io/github/stars/modelscope/AgentJet?style=for-the-badge&logo=github&logoColor=white&labelColor=181717&color=ffd700" alt="Stars"> | 2026.6 | ModelScope (Alibaba) | [Paper](https://arxiv.org/abs/2606.04484) |
 | [HarnessX](https://github.com/Darwin-Agent/HarnessX) | <img src="https://img.shields.io/github/stars/Darwin-Agent/HarnessX?style=for-the-badge&logo=github&logoColor=white&labelColor=181717&color=ffd700" alt="Stars"> | 2026.6 | Darwin-Agent | [Paper](https://arxiv.org/abs/2606.14249) |
+| [Dressage](https://github.com/Accio-Lab/Dressage) | <img src="https://img.shields.io/github/stars/Accio-Lab/Dressage?style=for-the-badge&logo=github&logoColor=white&labelColor=181717&color=ffd700" alt="Stars"> | 2026.6 | Accio-Lab | -- |
 | [Polar](https://github.com/NVIDIA-NeMo/ProRL-Agent-Server) | <img src="https://img.shields.io/github/stars/NVIDIA-NeMo/ProRL-Agent-Server?style=for-the-badge&logo=github&logoColor=white&labelColor=181717&color=ffd700" alt="Stars"> | 2026.5 | NVIDIA (NeMo) | [Paper](https://arxiv.org/abs/2605.24220) |
 | [uni-agent](https://github.com/verl-project/uni-agent) | <img src="https://img.shields.io/github/stars/verl-project/uni-agent?style=for-the-badge&logo=github&logoColor=white&labelColor=181717&color=ffd700" alt="Stars"> | 2026.4 | verl-project | -- |
 | [VeRL-Omni](https://github.com/verl-project/verl-omni) | <img src="https://img.shields.io/github/stars/verl-project/verl-omni?style=for-the-badge&logo=github&logoColor=white&labelColor=181717&color=ffd700" alt="Stars"> | 2026.4 | verl-project | -- |
@@ -137,6 +138,7 @@ Then just ask, e.g. *"my GRPO search agent's reward is flat but eval keeps dropp
 | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: |
 | [AgentJet](https://github.com/modelscope/AgentJet) | GRPO/PPO (swarm, multi-dim reward) | Both | Both | Multi | Swarm agentic RL (heterogeneous multi-agent, multi-task) | All (Custom/External/Rule) | Yes (tool calls, agent frameworks) |
 | [HarnessX](https://github.com/Darwin-Agent/HarnessX) | GRPO/PPO (slime/verl recipes) | Single | Outcome | Multi | Composable agent-harness foundry (ALFWorld/GAIA/WebShop/SWE-bench) | External + Custom | Yes (harness orchestrates tools/memory) |
+| [Dressage](https://github.com/Accio-Lab/Dressage) | GRPO | Both | Outcome | Multi | Agentic RL for any agent and sandbox (SWE-Gym/ALFWorld/HotpotQA) | External/Rule | Yes (whitebox: code/shell/file/retrieval; blackbox: opencode/openclaw/claude_code/codex) |
 | [Polar](https://github.com/NVIDIA-NeMo/ProRL-Agent-Server) | GRPO | Both | Outcome | Multi | Agentic RL on any harness (SWE-Bench/SWE-Gym) | External Verifier | Yes (real agent harnesses: shell/Codex/Claude Code) |
 | [uni-agent](https://github.com/verl-project/uni-agent) | GRPO/GSPO (partial rollout, fully-async) | Single | Outcome | Multi | SWE-Bench/Search/General Agent (1000+ concurrent) | All | Yes (unified model/tool/env abstractions) |
 | [VeRL-Omni](https://github.com/verl-project/verl-omni) | FlowGRPO/DanceGRPO/Diffusion DPO | Single | Outcome | Single | Multimodal generation RL (image/video/omni) | Model/External | No |

--- a/skills/agents-meet-rl/SKILL.md
+++ b/skills/agents-meet-rl/SKILL.md
@@ -24,7 +24,7 @@ likely causes, checks, and cited fixes for you to apply.
   paper/repo. Use for "which framework / benchmark" selection, to look
   up project names not routed via `problems/_INDEX.md`, and to answer
   "what's the idea behind X" by quoting its `Idea:` line.
-- **`database.json`** — machine-readable, 368 entries (each with a
+- **`database.json`** — machine-readable, 369 entries (each with a
   `takeaway` field mirroring the `Idea:` line) plus 3 paper-only
   algorithms (DAPO, Dr.GRPO, VAPO) whitelisted in
   `scripts/lint_skill.py`.

--- a/skills/agents-meet-rl/database.json
+++ b/skills/agents-meet-rl/database.json
@@ -52,6 +52,26 @@
     },
     {
       "category": "base_framework",
+      "name": "Dressage",
+      "github_url": "https://github.com/Accio-Lab/Dressage",
+      "papers": [],
+      "blog_urls": [],
+      "date": "2026.6",
+      "org": "Accio-Lab",
+      "rl_framework": null,
+      "domain": null,
+      "task": "Agentic RL for any agent and sandbox (SWE-Gym/ALFWorld/HotpotQA)",
+      "rl_algorithm": "GRPO",
+      "agent_arity": "Both",
+      "reward_phase": "Outcome",
+      "turn_mode": "Multi",
+      "reward_type": "External/Rule",
+      "tool_usage": "Yes (whitebox: code/shell/file/retrieval; blackbox: opencode/openclaw/claude_code/codex)",
+      "focus": null,
+      "takeaway": "Bridges policy rollouts, sandboxed tool execution, and training-data conversion through a shared proxy on slime, unifying whitebox Python tool loops and blackbox HTTP agents (opencode/openclaw/claude_code/codex) with TITO incremental tokenization to avoid retokenization drift."
+    },
+    {
+      "category": "base_framework",
       "name": "Polar",
       "github_url": "https://github.com/NVIDIA-NeMo/ProRL-Agent-Server",
       "papers": [

--- a/skills/agents-meet-rl/references/_INDEX.md
+++ b/skills/agents-meet-rl/references/_INDEX.md
@@ -13,7 +13,7 @@ Claude can cite specific work when giving recommendations — plus an
 
 | Category | File | Count | Use When |
 |---|---|---|---|
-| Base Frameworks | [base-frameworks.md](base-frameworks.md) | 23 | RL training frameworks for LLM agents (e.g. veRL, OpenRLHF, slime). Pick one as the base of your training stack. |
+| Base Frameworks | [base-frameworks.md](base-frameworks.md) | 24 | RL training frameworks for LLM agents (e.g. veRL, OpenRLHF, slime). Pick one as the base of your training stack. |
 | General / MultiTask Agents | [general-multitask.md](general-multitask.md) | 21 | Agents trained across many tasks/environments. Useful when you want one model that handles search + tool + code etc. |
 | Search & RAG Agents | [search-rag.md](search-rag.md) | 45 | Agents that interleave reasoning and retrieval. Most use rule-based EM/F1 outcome rewards or info-gain process rewards. |
 | Web & GUI Agents | [web-gui.md](web-gui.md) | 32 | Agents that drive browsers, mobile UIs, or desktop OSes. Grounding accuracy and long-horizon planning dominate. |

--- a/skills/agents-meet-rl/references/base-frameworks.md
+++ b/skills/agents-meet-rl/references/base-frameworks.md
@@ -2,11 +2,11 @@
 
 RL training frameworks for LLM agents (e.g. veRL, OpenRLHF, slime). Pick one as the base of your training stack.
 
-_Total: 23 entries._
+_Total: 24 entries._
 
 ## Contents
 
-AgentJet, HarnessX, Polar, uni-agent, OpenClaw-RL, Claw-R1, Open-AgentRL, NeMo-RL, RLinf, agent-lightning, siiRL, slime, ROLL, AReaL, MARTI, Tunix, RL2, verifiers, prime-rl, oat, veRL, OpenRLHF, trl.
+AgentJet, HarnessX, Dressage, Polar, uni-agent, OpenClaw-RL, Claw-R1, Open-AgentRL, NeMo-RL, RLinf, agent-lightning, siiRL, slime, ROLL, AReaL, MARTI, Tunix, RL2, verifiers, prime-rl, oat, veRL, OpenRLHF, trl.
 
 ### AgentJet
 - **Idea:** Decoupled swarm server/client design trains heterogeneous, non-shared-parameter multi-agent teams, with a context-merging timeline module for 1.5-10x rollout speedup.
@@ -23,6 +23,14 @@ AgentJet, HarnessX, Polar, uni-agent, OpenClaw-RL, Claw-R1, Open-AgentRL, NeMo-R
 - Algorithm: GRPO/PPO (slime/verl recipes) · Agent: Single · Turns: Multi · Tools: Yes (harness orchestrates tools/memory)
 - Reward phase: Outcome · Reward type: External + Custom
 - Task: Composable agent-harness foundry (ALFWorld/GAIA/WebShop/SWE-bench)
+
+### Dressage
+- **Idea:** Bridges policy rollouts, sandboxed tool execution, and training-data conversion through a shared proxy on slime, unifying whitebox Python tool loops and blackbox HTTP agents (opencode/openclaw/claude_code/codex) with TITO incremental tokenization to avoid retokenization drift.
+- `https://github.com/Accio-Lab/Dressage` · org: Accio-Lab · date: 2026.6
+- Paper(s): —
+- Algorithm: GRPO · Agent: Both · Turns: Multi · Tools: Yes (whitebox: code/shell/file/retrieval; blackbox: opencode/openclaw/claude_code/codex)
+- Reward phase: Outcome · Reward type: External/Rule
+- Task: Agentic RL for any agent and sandbox (SWE-Gym/ALFWorld/HotpotQA)
 
 ### Polar
 - **Idea:** Treats any real agent harness (Codex, Claude Code, shell) as the RL environment with token-faithful rollouts, so GRPO improves the exact agent that ships.


### PR DESCRIPTION
## What

Add [Dressage](https://github.com/Accio-Lab/Dressage) — a slime-based agentic RL training framework that unifies whitebox Python tool loops and blackbox HTTP agents (opencode/openclaw/claude_code/codex) through a shared inference proxy, with TITO (Token-In-Token-Out) incremental tokenization to eliminate retokenization drift across turns.

## Category

**Base Framework** — general-purpose agentic-RL training framework built on slime (via submodule, not a fork), same class as uni-agent / HarnessX / Polar.

## Project metadata

| Field | Value |
|---|---|
| Repo | https://github.com/Accio-Lab/Dressage |
| Org | Accio-Lab |
| Date | 2026.6 (open-sourced 2026-06-20) |
| Paper | — (GitHub citation only) |
| RL framework | slime |
| Algorithm | GRPO |
| Agent arity | Both (multi-agent supported) |
| Turn mode | Multi |
| Reward | Outcome · External/Rule |
| Tools | Yes (whitebox: code/shell/file/retrieval; blackbox: opencode/openclaw/claude_code/codex) |

## Changes

- `database.json` — insert Dressage entry into `base_framework` (date-descending, after HarnessX)
- `references/base-frameworks.md` — add entry block + Contents + `_Total` 23 → 24
- `references/_INDEX.md` — base-frameworks count 23 → 24
- `README.md` — badge 23 → 24, main table + technical-details table, corpus count 368 → 369
- `SKILL.md` — database.json entry count 368 → 369

## Verification

- `python3 scripts/lint_skill.py` → **0 errors**
- `database.json` valid JSON